### PR TITLE
Adds Ability To Purchase Portals

### DIFF
--- a/conf/mod_assistant.conf.dist
+++ b/conf/mod_assistant.conf.dist
@@ -18,6 +18,25 @@ Assistant.Containers.Enabled = 1
 
 #################################
 #
+# Enable portal training
+# Allows Any character to learn portals to major cities
+#
+# Defaults:
+# Assistant.Portals.Enabled    = 1
+# Assistant.Portals.Cost       = 100000
+# Assistant.Portals.Horde      = "11417,11418,11420,32267,49361"
+# Assistant.Portals.Alliance   = "10059,11416,11419,32266,49360"
+# Assistant.Portals.Neutral    = "33691,53142"
+#
+
+Assistant.Portals.Enabled    = 1
+Assistant.Portals.Cost       = 100000
+Assistant.Portals.Horde      = "11417,11418,11420,32267,49361"
+Assistant.Portals.Alliance   = "10059,11416,11419,32266,49360"
+Assistant.Portals.Neutral    = "33691,53142"
+
+#################################
+#
 # Enable utility features
 # This includes name change, character customization, race change and faction change
 # The cost is set in copper

--- a/src/mod_assistant.h
+++ b/src/mod_assistant.h
@@ -17,6 +17,7 @@ enum GossipId
     ASSISTANT_GOSSIP_FLIGHT_PATHS    = 600,
     ASSISTANT_GOSSIP_UTILITIES       = 700,
     ASSISTANT_GOSSIP_PROFESSIONS     = 800,
+    ASSISTANT_GOSSIP_PORTALS         = 900,
 };
 
 enum VendorId
@@ -72,6 +73,22 @@ private:
     bool ContainersEnabled;
 
     uint32 GetGlyphId(uint32 /*id*/, bool /*major*/);
+
+    // Portals
+    bool PortalsEnabled;
+    uint32 PortalCost;
+    bool CanBuyPortals(Player* player) const;
+
+    static std::vector<uint32> ParsePortalIds(const std::string &configStr);
+    std::string HordePortalIdConfig;
+    std::string AlliancePortalIdConfig;
+    std::string NeutralPortalIdConfig;
+    void ConfigurePortals();
+
+    std::vector<uint32> HordePortals {};
+    std::vector<uint32> AlliancePortals {};
+    std::vector<uint32> NeutralPortals {};
+
 
     // Utilities
     bool UtilitiesEnabled;

--- a/src/mod_assistant_config.cpp
+++ b/src/mod_assistant_config.cpp
@@ -8,6 +8,14 @@ void Assistant::OnAfterConfigLoad(bool /*reload*/)
     GemsEnabled = sConfigMgr->GetOption<bool>("Assistant.Gems.Enabled", 1);
     ContainersEnabled = sConfigMgr->GetOption<bool>("Assistant.Containers.Enabled", 1);
 
+    // Portals
+    PortalsEnabled = sConfigMgr->GetOption<bool>("Assistant.Portals.Enabled", 1);
+    PortalCost = sConfigMgr->GetOption<uint32>("Assistant.Portals.Cost", 100000);
+    HordePortalIdConfig = sConfigMgr->GetOption<std::string>("Assistant.Portals.Horde", "");
+    AlliancePortalIdConfig = sConfigMgr->GetOption<std::string>("Assistant.Portals.Alliance", "");
+    NeutralPortalIdConfig = sConfigMgr->GetOption<std::string>("Assistant.Portals.Neutral", "");
+    ConfigurePortals();
+
     // Utilities
     UtilitiesEnabled = sConfigMgr->GetOption<bool>("Assistant.Utilities.Enabled", 1);
     NameChangeCost = sConfigMgr->GetOption<uint32>("Assistant.Utilities.NameChange.Cost", 100000);

--- a/src/mod_assistant_functions.cpp
+++ b/src/mod_assistant_functions.cpp
@@ -1,3 +1,5 @@
+#include "Tokenize.h"
+#include "Log.h"
 #include "mod_assistant.h"
 
 uint32 Assistant::GetGlyphId(uint32 id, bool major)
@@ -365,4 +367,41 @@ uint32 Assistant::GetProfessionCost(Player* player, uint32 id)
         return GrandMasterProfessionCost;
 
     return 0;
+}
+
+bool Assistant::CanBuyPortals(Player* player) const {
+    if (!PortalsEnabled) {
+        return false;
+    }
+
+    PlayerSpellMap spells = player->GetSpellMap();
+    auto portalIds = player->GetTeamId() == TEAM_HORDE ? HordePortals : AlliancePortals;
+
+    return std::any_of(portalIds.begin(), portalIds.end(), [&](const uint32 &item) {
+        return !spells.contains(item);
+    });
+}
+
+std::vector<uint32> Assistant::ParsePortalIds(const std::string& configStr) {
+    auto stringViews = Acore::Tokenize(configStr, ',', false);
+    std::vector<uint32> portalIds;
+    portalIds.reserve(stringViews.size());
+
+    for (const auto& view : stringViews) {
+        portalIds.push_back(Acore::StringTo<uint32>(view).value());
+    }
+
+    return portalIds;
+}
+
+void Assistant::ConfigurePortals() {
+    LOG_INFO("server", "Loading portals...");
+
+    HordePortals = ParsePortalIds(HordePortalIdConfig);
+    AlliancePortals = ParsePortalIds(AlliancePortalIdConfig);
+    NeutralPortals = ParsePortalIds(NeutralPortalIdConfig);
+
+    LOG_INFO("server", Acore::StringFormatFmt("Horde Portal IDs: {}", HordePortalIdConfig));
+    LOG_INFO("server", Acore::StringFormatFmt("Alliance Portal IDs: {}", AlliancePortalIdConfig));
+    LOG_INFO("server", Acore::StringFormatFmt("Neutral Portal IDs: {}", NeutralPortalIdConfig));
 }

--- a/src/mod_assistant_npc.cpp
+++ b/src/mod_assistant_npc.cpp
@@ -19,6 +19,9 @@ bool Assistant::OnGossipHello(Player* player, Creature* creature)
     if (UtilitiesEnabled)
         AddGossipItemFor(player, GOSSIP_ICON_CHAT, "I want utilities", GOSSIP_SENDER_MAIN, ASSISTANT_GOSSIP_UTILITIES);
 
+    if (CanBuyPortals(player))
+        AddGossipItemFor(player, GOSSIP_ICON_TAXI, "I want to be a mage!", GOSSIP_SENDER_MAIN, ASSISTANT_GOSSIP_PORTALS, "Do you wish to continue?", PortalCost, false);
+
     if (CanUnlockFlightPaths(player))
         AddGossipItemFor(player, GOSSIP_ICON_CHAT, "I want to unlock flight paths", GOSSIP_SENDER_MAIN, ASSISTANT_GOSSIP_FLIGHT_PATHS);
 
@@ -311,6 +314,17 @@ bool Assistant::OnGossipSelect(Player* player, Creature* creature, uint32 sender
 
         SetProfession(player, skill);
         OnGossipSelect(player, creature, GOSSIP_SENDER_MAIN, 1);
+    }
+    else if (action == ASSISTANT_GOSSIP_PORTALS) {
+        std::vector<uint32> portals = player->GetTeamId() == TEAM_HORDE ? HordePortals : AlliancePortals;
+        portals.insert(portals.end(), NeutralPortals.begin(), NeutralPortals.end());
+
+        if (player->HasEnoughMoney(PortalCost)) {
+            for(const uint32 p : portals) {
+                player->learnSpell(p);
+            }
+            player->ModifyMoney(-PortalCost);
+        }
     }
 
     return true;


### PR DESCRIPTION
This PR provides the option to buy portal spells for any character.  The character will learn their faction-specific portals + the neutral portals.  Portal list is configurable in the config, as well as portal training cost.